### PR TITLE
Ci/add boxlang to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - development
       - master
+  workflow_dispatch:
 
 env:
   MODULE_ID: sqlformatter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build & Publish
     needs: tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ jobs:
   # UPDATE TO THE MODULE REPO SO PR'S CAN REUSE IT
   tests:
     uses: coldbox-modules/sqlformatter/.github/workflows/tests.yml@development
+    secrets: inherit
 
   # Format PR
   format:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
   # Format PR
   format:
     name: Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DB_USER: root
       DB_PASSWORD: root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Setup CommandBox CLI
         uses: Ortus-Solutions/setup-commandbox@main
 
+      - name: Update Commandbox Boxlang Module
+        if: ${{ matrix.cfengine == 'boxlang@1' }}
+        run:
+          box install --force commandbox-boxlang
+
       # Not Needed in this module
       #- name: Setup Environment For Testing Process
       #  working-directory: ./test-harness

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,17 @@ jobs:
     env:
       DB_USER: root
       DB_PASSWORD: root
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         cfengine: [ "lucee@5", "adobe@2018", "adobe@2021" ]
+        coldboxVersion: [ "^6.0.0", "^7.0.0" ]
+        experimental: [ false ]
+        include:
+          - cfengine: "boxlang@1"
+            coldboxVersion: "be"
+            experimental: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -30,7 +37,7 @@ jobs:
       #    mysql -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }} < test-harness/tests/resources/coolblog.sql
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: "adopt"
           java-version: "11"
@@ -55,7 +62,7 @@ jobs:
       #    printf "DB_BUNDLENAME=com.mysql.cj\n" >> .env
 
       - name: Cache CommandBox Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         if: ${{ true }}
         with:
           path: ~/.CommandBox/artifacts
@@ -66,7 +73,9 @@ jobs:
       - name: Install Test Harness Dependencies
         run: |
           box install
-          cd test-harness && box install
+          cd test-harness
+          box package set dependencies.coldbox=${{ matrix.coldboxVersion }}
+          box install
 
       - name: Start ${{ matrix.cfengine }} Server
         run: |
@@ -83,17 +92,17 @@ jobs:
           box testbox run --verbose outputFile=test-harness/tests/results/test-results outputFormats=json,antjunit
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: test-harness/tests/results/**/*.xml
-          check_name: "${{ matrix.cfengine }} Test Results"
+          junit_files: test-harness/tests/results/**/*.xml
+          check_name: "${{ matrix.cfengine }} ColdBox ${{ matrix.coldboxVersion }} Test Results"
 
       - name: Upload Test Results to Artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.cfengine }}
+          name: test-results-${{ matrix.cfengine }}-${{ matrix.coldboxVersion }}
           path: |
             test-harness/tests/results/**/*
 
@@ -104,9 +113,9 @@ jobs:
 
       - name: Upload Debug Logs To Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: Failure Debugging Info - ${{ matrix.cfengine }}
+          name: Failure Debugging Info - ${{ matrix.cfengine }} - ${{ matrix.coldboxVersion }}
           path: |
             .engine/**/logs/*
             .engine/**/WEB-INF/cfusion/logs/*
@@ -120,6 +129,6 @@ jobs:
           SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
           SLACK_ICON_EMOJI: ":bell:"
           SLACK_MESSAGE: '${{ github.repository }} tests failed :cry:'
-          SLACK_TITLE: ${{ github.repository }} Tests For ${{ matrix.cfengine }} failed
+          SLACK_TITLE: ${{ github.repository }} Tests For ${{ matrix.cfengine }} with ColdBox ${{ matrix.coldboxVersion }} failed
           SLACK_USERNAME: CI
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A CFML wrapper for the Vertical Blank sql-formatter java library.
 
 [![Release](https://github.com/coldbox-modules/sqlFormatter/actions/workflows/ci.yml/badge.svg)](https://github.com/coldbox-modules/sqlFormatter/actions/workflows/ci.yml)
 
+## System requirements
+
+* [Boxlang](https://www.boxlang.io)
+* Adobe 2018+
+* Lucee 5
+
 ## Installation
 
 Using CommandBox:

--- a/server-boxlang@1.json
+++ b/server-boxlang@1.json
@@ -22,7 +22,7 @@
     "JVM":{
         "heapSize":"1024",
         "javaVersion":"openjdk21_jdk",
-        "args":"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999"
+        "args":"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999 -Dboxlang.debugMode=true"
     },
     "cfconfig":{
         "file":".cfconfig.json"

--- a/server-boxlang@1.json
+++ b/server-boxlang@1.json
@@ -1,0 +1,36 @@
+{
+    "app":{
+        "cfengine":"boxlang@be",
+        "serverHomeDirectory":".engine/boxlang"
+    },
+    "name":"sqlFormatter-boxlang@1",
+    "force":true,
+    "openBrowser":false,
+    "web":{
+        "directoryBrowsing":true,
+        "http":{
+            "port":"60299"
+        },
+        "rewrites":{
+            "enable":"true"
+        },
+        "webroot":"test-harness",
+        "aliases":{
+            "/moduleroot/sqlFormatter":"./"
+        }
+    },
+    "JVM":{
+        "heapSize":"1024",
+        "javaVersion":"openjdk21_jdk",
+        "args":"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999"
+    },
+    "cfconfig":{
+        "file":".cfconfig.json"
+    },
+    "env":{
+        "BOXLANG_DEBUG":true
+    },
+    "scripts":{
+        "onServerInitialInstall":"install bx-mail,bx-mysql,bx-derby,bx-compat-cfml@be,bx-unsafe-evaluate,bx-esapi --noSave"
+    }
+}


### PR DESCRIPTION
Boxlang was added to tests matrix, enable workflow dispatch to retrieve boxlang test results triggered

Upgrade deprecated versions of:
* actions/upload-artifact
* EnricoMi/publish-unit-test-result-action
* actions/setup-java
* actions/cache